### PR TITLE
Fix wrong display when input changes before server response

### DIFF
--- a/src/input_controller.ts
+++ b/src/input_controller.ts
@@ -33,17 +33,21 @@ export function inputController(element: HTMLInputElement) {
     async function updateUIAfterServerResponse(urlToCheck:string) {
             try {
                 const result = await checkUrlExists(urlToCheck);
-                resetClasses();
-                if (result.exists) {
-                    element.classList.add("border-valid");
-                    message.classList.add("text-valid");
-                    message.textContent = `This URL exists and it is ${result.type}`;
-                } 
-                else {
-                    element.classList.add("border-invalid");
-                    message.classList.add("text-invalid");
-                    message.textContent = "This URL don't exists in the server";
+                if (urlToCheck===element.value){
+                    resetClasses();
+                    if (result.exists) {
+                        element.classList.add("border-valid");
+                        message.classList.add("text-valid");
+                        message.textContent = `This URL exists and it is ${result.type}`;
+                    } 
+                    else {
+                        element.classList.add("border-invalid");
+                        message.classList.add("text-invalid");
+                        message.textContent = "This URL don't exists in the server";
+                    }
+
                 }
+               
             } catch (err) {
                     message.textContent = "Data cannot be fetched from the server at this time";
         

--- a/src/url_api.ts
+++ b/src/url_api.ts
@@ -13,7 +13,7 @@ const folderListUrl= new Set([
     "https://app.tuta.com/images"
 ]); 
 export async function checkUrlExists(url: string): Promise<{ exists: boolean; type: "file" | "folder" | null }> {
-    await new Promise(resolve => setTimeout(resolve, 200));
+    await new Promise(resolve => setTimeout(resolve, 3000));
 
     if (fileListUrl.has(url)){
         return {exists:true, type:"file"};


### PR DESCRIPTION
This is a very simple and fast fix. I added a condition to check if the input value is still the same. If it is, we render the result, if it has changed, we don’t render anything, and the throttle function already handles refetching for the latest value. 

I also increased the waiting time for the server to better mock a very slow response, so the effect of this change is clearer. For me, this is the simplest solution, though I don’t like that we still await the server response even when it’s no longer needed. A more appropriate approach would be to use AbortController.abort() in the onchange function, but that would require more changes to the logic.